### PR TITLE
feat(llm): integrate LLM wrapper as LLM gateway for Web-Scout

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,8 @@
-# Lily-Core Environment Configuration
+# Web-Scout Environment Configuration
 # Copy this file to .env and fill in your actual values
 
-# --- Gemini API Key ---
-# Replace with your actual Gemini API key
-GEMINI_API_KEY=your_gemini_api_key_here
+# --- LLM Configuration (OpenAI-compatible endpoint) ---
+# Example: http://localhost:11435 for LLM Wrapper
+# Or any OpenAI-compatible API endpoint (Ollama, LM Studio, etc.)
+LLM_ENDPOINT=http://localhost:11435
+LLM_MODEL=gemini-3-flash-preview

--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,5 @@
-# Web-Scout Environment Configuration
-# Copy this file to .env and fill in your actual values
-
-# --- LLM Configuration (OpenAI-compatible endpoint) ---
-# Example: http://localhost:11435 for LLM Wrapper
-# Or any OpenAI-compatible API endpoint (Ollama, LM Studio, etc.)
-LLM_ENDPOINT=http://localhost:11435
+# LLM Configuration (OpenAI-compatible endpoint)
+# Uses LLM_WRAPPER_URL env var as single source of truth
+# Connects to LLM Wrapper for AI summarization
+LLM_ENDPOINT_URL=http://llm-wrapper:11435
 LLM_MODEL=gemini-3-flash-preview

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -2,7 +2,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: ['**']
+    branches: [main, dev]
   pull_request:
     branches: [main, dev]
 

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -107,13 +107,16 @@ jobs:
             DOCKER_USER=$(az keyvault secret show --vault-name nstutcommonkv --name dockerhub-username --query value -o tsv)
             DOCKER_TOKEN=$(az keyvault secret show --vault-name nstutcommonkv --name dockerhub-token --query value -o tsv)
             GH_PAT=$(az keyvault secret show --vault-name nstutcommonkv --name github-pat --query value -o tsv)
+            LLM_ENDPOINT_URL=$(az keyvault secret show --vault-name nstutcommonkv --name llm-endpoint-url --query value -o tsv)
             
             echo "::add-mask::$DOCKER_TOKEN"
             echo "::add-mask::$GH_PAT"
+            echo "::add-mask::$LLM_ENDPOINT_URL"
             
             echo "DOCKER_USER=$DOCKER_USER" >> $GITHUB_OUTPUT
             echo "DOCKER_TOKEN=$DOCKER_TOKEN" >> $GITHUB_OUTPUT
             echo "GH_PAT=$GH_PAT" >> $GITHUB_OUTPUT
+            echo "LLM_ENDPOINT_URL=$LLM_ENDPOINT_URL" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -156,4 +159,4 @@ jobs:
           token: ${{ steps.kv.outputs.GH_PAT }}
           repository: UpperMoon0/LilyIV
           event-type: web-scout-pushed
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "image_tag": "${{ env.IMAGE_TAG }}"}'
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "image_tag": "${{ env.IMAGE_TAG }}", "llm_endpoint_url": "${{ steps.kv.outputs.LLM_ENDPOINT_URL }}"}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the Web-Scout directory content to the working directory
 COPY . /app/Web-Scout
 
-# Copy and set environment file
-COPY .env* /app/Web-Scout/
-
 # Set working directory to the application directory
 WORKDIR /app/Web-Scout
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from core.config import WEB_SEARCH_TOOL_SCHEMA
 from services.search_service import perform_core_search
 from services.cache_service import search_cache
-from core.settings import settings_manager, mask_api_keys
+from core.settings import settings_manager
 import json
 
 router = APIRouter()
@@ -157,21 +157,4 @@ async def get_settings():
 @router.post("/settings")
 async def update_settings(settings: dict):
     """Update configuration settings."""
-    # Handle backward compatibility: convert single key to list
-    if 'gemini_api_key' in settings and 'gemini_api_keys' not in settings:
-        # Old format: single key
-        single_key = settings.pop('gemini_api_key')
-        if single_key and single_key.strip():
-            # Only add if not empty
-            settings['gemini_api_keys'] = [single_key.strip()]
-        else:
-            settings['gemini_api_keys'] = []
-    
-    # Ensure gemini_api_keys is a list
-    if 'gemini_api_keys' in settings and not isinstance(settings['gemini_api_keys'], list):
-        if isinstance(settings['gemini_api_keys'], str):
-            settings['gemini_api_keys'] = [settings['gemini_api_keys']]
-        else:
-            settings['gemini_api_keys'] = []
-    
     return settings_manager.save_settings(settings)

--- a/core/config.py
+++ b/core/config.py
@@ -1,21 +1,7 @@
-import os
 from dotenv import load_dotenv
-import google.generativeai as genai
 
-# Load environment variables
 load_dotenv()
 
-# Configure Gemini AI
-GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
-
-model = None
-if GEMINI_API_KEY:
-    genai.configure(api_key=GEMINI_API_KEY)
-    model = genai.GenerativeModel('gemini-2.5-flash')
-else:
-    print("WARNING: GEMINI_API_KEY not found. AI features will be disabled.")
-
-# Shared tool schema definition
 WEB_SEARCH_TOOL_SCHEMA = {
     'name': 'web_search',
     'description': 'Perform a web search and provide summaries',

--- a/core/settings.py
+++ b/core/settings.py
@@ -10,8 +10,8 @@ DEFAULT_SETTINGS = {
     "safe_search": True,
     "max_results": 10,
     "max_cache_size": 20,
-    "gemini_api_keys": [],
-    "gemini_model": "gemini-2.0-flash",
+    "llm_endpoint": "",
+    "llm_model": "gemini-3-flash-preview",
     "summary_prompt_template": """Based on the following search results for the query: "{query}"
 
 Please provide a concise summary of the key findings in 2-3 paragraphs. Focus on the most relevant and important information.
@@ -37,26 +37,11 @@ Detailed Analysis:"""
 }
 
 
-def mask_api_key(key: str) -> str:
-    """Mask an API key for display (show last 4 characters)."""
-    if len(key) <= 4:
-        return "****"
-    return f"...{key[-4:]}"
-
-
-def mask_api_keys(keys: list) -> list:
-    """Mask a list of API keys for display."""
-    return [mask_api_key(key) for key in keys]
-
-
 class SettingsManager:
     def __init__(self):
         self.settings = self._load_settings()
-        self._current_key_index = 0
 
     def _load_settings(self) -> Dict[str, Any]:
-        """Load settings from JSON file or return defaults."""
-        # Ensure data directory exists
         os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
         
         if not os.path.exists(SETTINGS_FILE):
@@ -65,15 +50,12 @@ class SettingsManager:
         try:
             with open(SETTINGS_FILE, "r") as f:
                 saved_settings = json.load(f)
-                # Merge with defaults to ensure all keys exist
                 return {**DEFAULT_SETTINGS, **saved_settings}
         except Exception as e:
             print(f"Error loading settings: {e}")
             return DEFAULT_SETTINGS.copy()
 
     def save_settings(self, new_settings: Dict[str, Any]) -> Dict[str, Any]:
-        """Update and save settings to JSON file."""
-        # Only update known keys to prevent pollution
         for key in DEFAULT_SETTINGS.keys():
             if key in new_settings:
                 self.settings[key] = new_settings[key]
@@ -88,31 +70,10 @@ class SettingsManager:
         return self.settings
 
     def get_settings(self) -> Dict[str, Any]:
-        """Get current settings with masked API keys."""
-        # Return a copy with masked API keys
-        settings = self.settings.copy()
-        settings["gemini_api_keys"] = mask_api_keys(settings.get("gemini_api_keys", []))
-        return settings
-
-    def get_raw_api_keys(self) -> list:
-        """Get raw (unmasked) API keys for internal use."""
-        return self.settings.get("gemini_api_keys", [])
-
-    def get_api_key_count(self) -> int:
-        """Get the number of configured API keys."""
-        return len(self.settings.get("gemini_api_keys", []))
-
-    def get_current_api_key_index(self) -> int:
-        """Get the current API key index for round-robin."""
-        return self._current_key_index % max(1, self.get_api_key_count())
-
-    def advance_api_key(self) -> None:
-        """Advance to the next API key in round-robin."""
-        self._current_key_index = (self._current_key_index + 1) % max(1, self.get_api_key_count())
+        return self.settings.copy()
 
     def get(self, key: str) -> Any:
-        """Get a specific setting value."""
         return self.settings.get(key, DEFAULT_SETTINGS.get(key))
 
-# Global instance
+
 settings_manager = SettingsManager()

--- a/core/settings.py
+++ b/core/settings.py
@@ -72,8 +72,8 @@ class SettingsManager:
     def get_settings(self) -> Dict[str, Any]:
         return self.settings.copy()
 
-    def get(self, key: str) -> Any:
-        return self.settings.get(key, DEFAULT_SETTINGS.get(key))
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.settings.get(key, default if default is not None else DEFAULT_SETTINGS.get(key))
 
 
 settings_manager = SettingsManager()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 fastapi
 uvicorn
 ddgs
-google-generativeai
 python-dotenv
 requests
 beautifulsoup4

--- a/services/search_service.py
+++ b/services/search_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import time
 import httpx
 from services.web_scraper import scrape_webpage_content
@@ -13,7 +14,7 @@ async def call_llm(prompt: str, model_name: str = None, max_retries: int = 3) ->
     if model_name is None:
         model_name = settings_manager.get("llm_model", "gemini-3-flash-preview")
     
-    llm_endpoint = settings_manager.get("llm_endpoint")
+    llm_endpoint = os.getenv("LLM_ENDPOINT_URL") or settings_manager.get("llm_endpoint")
     
     if not llm_endpoint:
         raise Exception("No LLM endpoint configured. Set 'llm_endpoint' in settings.")
@@ -109,19 +110,14 @@ async def perform_core_search(query: str, mode_str: str) -> dict:
 
         llm_start = time.perf_counter()
         prompt = generate_search_prompt(query, results_with_content, mode_str)
-        
-        llm_endpoint = settings_manager.get("llm_endpoint")
+
+        llm_endpoint = os.getenv("LLM_ENDPOINT_URL") or settings_manager.get("llm_endpoint")
+
         if not llm_endpoint:
-            summary_lines = ["**LLM not configured. Displaying top search results:**\n"]
-            for i, res in enumerate(results_with_content[:5]):
-                title = res.get('title', 'No Title')
-                href = res.get('href', '#')
-                body = res.get('body', 'No description available.')
-                summary_lines.append(f"{i+1}. **[{title}]({href})**\n   {body}\n")
-            summary = "\n".join(summary_lines)
-        else:
-            model_name = settings_manager.get("llm_model", "gemini-3-flash-preview")
-            summary = await call_llm(prompt, model_name)
+            raise Exception("No LLM endpoint configured. Set 'LLM_ENDPOINT_URL' env var or 'llm_endpoint' in settings.")
+        
+        model_name = settings_manager.get("llm_model", "gemini-3-flash-preview")
+        summary = await call_llm(prompt, model_name)
         
         timing["llm_time"] = time.perf_counter() - llm_start
         timing["total_time"] = time.perf_counter() - start_time

--- a/services/search_service.py
+++ b/services/search_service.py
@@ -1,8 +1,6 @@
 import asyncio
-import os
 import time
-import google.generativeai as genai
-from google.api_core.exceptions import TooManyRequests, ServiceUnavailable, BadRequest
+import httpx
 from services.web_scraper import scrape_webpage_content
 from utils.prompt_builder import generate_search_prompt
 from services.cache_service import search_cache
@@ -10,83 +8,52 @@ from ddgs import DDGS
 from core.settings import settings_manager
 
 
-def get_llm_model_with_retry(api_key: str = None, model_name: str = None):
-    """Get configured Gemini model."""
-    if not api_key:
-        api_key = os.getenv("GEMINI_API_KEY")
+async def call_llm(prompt: str, model_name: str = None, max_retries: int = 3) -> str:
+    """Call LLM via OpenAI-compatible API with retry logic."""
+    if model_name is None:
+        model_name = settings_manager.get("llm_model", "gemini-3-flash-preview")
     
-    if not model_name:
-        model_name = settings_manager.get("gemini_model")
-
-    if not api_key:
-        return None
-
-    try:
-        genai.configure(api_key=api_key)
-        return genai.GenerativeModel(model_name)
-    except Exception as e:
-        print(f"Error configuring Gemini: {e}")
-        return None
-
-
-async def call_gemini_with_retry(model, prompt: str, max_retries: int = 3) -> str:
-    """Call Gemini API with round-robin retry on rate limit or invalid key."""
+    llm_endpoint = settings_manager.get("llm_endpoint")
     
-    for attempt in range(max_retries):
-        try:
-            # Use async generation if available
-            if hasattr(model, 'generate_content_async'):
-                response = await model.generate_content_async(prompt)
-            else:
-                # Fallback for models without async support
-                loop = asyncio.get_running_loop()
-                response = await loop.run_in_executor(None, model.generate_content, prompt)
-            return response.text
-        except BadRequest as e:
-            error_msg = str(e).lower()
-            if "api key not valid" in error_msg or "api_key_invalid" in error_msg:
-                print(f"Invalid API key error (attempt {attempt + 1}/{max_retries}): {e}")
-                # Always advance key for invalid API key, regardless of key count
-                settings_manager.advance_api_key()
-                # Get FRESH api_keys list and current index
-                api_keys = settings_manager.get_raw_api_keys()
-                current_index = settings_manager.get_current_api_key_index()
-                if current_index < len(api_keys):
-                    next_key = api_keys[current_index]
-                    model = get_llm_model_with_retry(api_key=next_key)
-                    if model is None:
-                        raise Exception("No valid API key available after retry")
-                else:
-                    # No more keys to try
-                    raise Exception("No valid API key available - all keys exhausted")
-            else:
-                # Other BadRequest errors (not API key related)
-                print(f"Bad request error (attempt {attempt + 1}/{max_retries}): {e}")
-                raise
-        except (TooManyRequests, ServiceUnavailable) as e:
-            print(f"Rate limit error (attempt {attempt + 1}/{max_retries}): {e}")
-            # Get fresh api_keys list each retry
-            api_keys = settings_manager.get_raw_api_keys()
-            key_count = len(api_keys)
-            
-            # Advance to next key for round-robin
-            if key_count > 1:
-                settings_manager.advance_api_key()
-                # Get FRESH current index after advancing
-                current_index = settings_manager.get_current_api_key_index()
-                next_key = api_keys[current_index]
-                model = get_llm_model_with_retry(api_key=next_key)
-                if model is None:
-                    raise Exception("No valid API key available after retry")
-            else:
-                # Single key, wait and retry with exponential backoff
-                wait_time = (2 ** attempt) * 1
-                await asyncio.sleep(wait_time)
-        except Exception as e:
-            print(f"Error calling Gemini: {e}")
-            raise
+    if not llm_endpoint:
+        raise Exception("No LLM endpoint configured. Set 'llm_endpoint' in settings.")
     
-    raise Exception("Max retries exceeded for Gemini API")
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        for attempt in range(max_retries):
+            try:
+                body = {
+                    "model": model_name,
+                    "messages": [
+                        {"role": "user", "content": prompt}
+                    ],
+                    "temperature": 0.3,
+                    "max_tokens": 8192
+                }
+                
+                response = await client.post(f"{llm_endpoint}/v1/chat/completions", json=body)
+                
+                if response.status_code == 429:
+                    wait_time = (2 ** attempt) * 1
+                    await asyncio.sleep(wait_time)
+                    continue
+                    
+                response.raise_for_status()
+                result = response.json()
+                return result["choices"][0]["message"]["content"]
+                
+            except httpx.HTTPStatusError as e:
+                if response.status_code == 401:
+                    raise Exception(f"LLM API authentication failed: {e}")
+                print(f"LLM API error (attempt {attempt + 1}/{max_retries}): {e}")
+                if attempt == max_retries - 1:
+                    raise
+            except Exception as e:
+                print(f"Error calling LLM (attempt {attempt + 1}/{max_retries}): {e}")
+                if attempt == max_retries - 1:
+                    raise
+                await asyncio.sleep(1)
+        
+        raise Exception("Max retries exceeded for LLM API")
 
 
 async def perform_core_search(query: str, mode_str: str) -> dict:
@@ -100,7 +67,6 @@ async def perform_core_search(query: str, mode_str: str) -> dict:
     }
 
     try:
-        # Get search results using DDGS in a separate thread to avoid blocking
         search_start = time.perf_counter()
         loop = asyncio.get_running_loop()
         
@@ -124,7 +90,6 @@ async def perform_core_search(query: str, mode_str: str) -> dict:
                 "timing": timing
             }
 
-        # Concurrently scrape content from top 5 results
         scrape_start = time.perf_counter()
         tasks = []
         for i, result in enumerate(results[:5]):
@@ -139,45 +104,28 @@ async def perform_core_search(query: str, mode_str: str) -> dict:
             result_with_content['full_content'] = content
             results_with_content.append(result_with_content)
         
-        # Add remaining results without scraping
         results_with_content.extend(results[5:])
         timing["scrape_time"] = time.perf_counter() - scrape_start
 
-        # Generate prompt and get LLM summary asynchronously
         llm_start = time.perf_counter()
         prompt = generate_search_prompt(query, results_with_content, mode_str)
         
-        # Get API key for round-robin
-        api_keys = settings_manager.get_raw_api_keys()
-        if api_keys:
-            current_index = settings_manager.get_current_api_key_index()
-            api_key = api_keys[current_index]
-        else:
-            api_key = os.getenv("GEMINI_API_KEY")
-        
-        model = get_llm_model_with_retry(api_key=api_key)
-
-        if model:
-            summary = await call_gemini_with_retry(model, prompt)
-        else:
-            # Fallback: Generate a basic summary from search snippets
-            summary_lines = ["**AI Summarization unavailable. Displaying top search results:**\n"]
+        llm_endpoint = settings_manager.get("llm_endpoint")
+        if not llm_endpoint:
+            summary_lines = ["**LLM not configured. Displaying top search results:**\n"]
             for i, res in enumerate(results_with_content[:5]):
                 title = res.get('title', 'No Title')
                 href = res.get('href', '#')
                 body = res.get('body', 'No description available.')
                 summary_lines.append(f"{i+1}. **[{title}]({href})**\n   {body}\n")
-            
             summary = "\n".join(summary_lines)
+        else:
+            model_name = settings_manager.get("llm_model", "gemini-3-flash-preview")
+            summary = await call_llm(prompt, model_name)
+        
         timing["llm_time"] = time.perf_counter() - llm_start
-
         timing["total_time"] = time.perf_counter() - start_time
 
-        # Advance to next key for round-robin after successful call
-        if api_keys:
-            settings_manager.advance_api_key()
-
-        # Add to cache
         search_cache.add(query, mode_str, results_with_content, summary, timing)
 
         return {

--- a/tests/unit/test_search_service.py
+++ b/tests/unit/test_search_service.py
@@ -28,7 +28,8 @@ async def test_search_with_llm():
     with patch('services.search_service.DDGS') as MockDDGS, \
          patch('services.search_service.scrape_webpage_content') as mock_scrape, \
          patch('services.search_service.settings_manager') as mock_settings, \
-         patch('services.search_service.call_llm') as mock_call_llm:
+         patch('services.search_service.call_llm') as mock_call_llm, \
+         patch('services.search_service.os.getenv') as mock_getenv:
         
         mock_ddgs_instance = MockDDGS.return_value
         mock_ddgs_instance.__enter__.return_value = mock_ddgs_instance
@@ -36,12 +37,13 @@ async def test_search_with_llm():
         
         mock_scrape.return_value = "Full scraped content"
         
-        mock_settings.get.side_effect = lambda key: {
-            "llm_endpoint": "http://localhost:11435",
+        mock_getenv.return_value = "http://localhost:11435"
+        
+        mock_settings.get.side_effect = lambda key, default=None: {
             "llm_model": "gemini-3-flash-preview",
             "max_results": 10,
             "safe_search": True,
-        }.get(key)
+        }.get(key, default)
         
         mock_call_llm.return_value = "AI Generated Summary"
 
@@ -54,10 +56,11 @@ async def test_search_with_llm():
 
 @pytest.mark.asyncio
 async def test_search_without_llm_endpoint_fallback():
-    """Test fallback formatting when LLM endpoint is not configured."""
+    """Test error when LLM endpoint is not configured."""
     with patch('services.search_service.DDGS') as MockDDGS, \
          patch('services.search_service.scrape_webpage_content') as mock_scrape, \
-         patch('services.search_service.settings_manager') as mock_settings:
+         patch('services.search_service.settings_manager') as mock_settings, \
+         patch('services.search_service.os.getenv') as mock_getenv:
         
         mock_ddgs_instance = MockDDGS.return_value
         mock_ddgs_instance.__enter__.return_value = mock_ddgs_instance
@@ -65,16 +68,15 @@ async def test_search_without_llm_endpoint_fallback():
         
         mock_scrape.return_value = "Full scraped content"
         
-        mock_settings.get.side_effect = lambda key: {
-            "llm_endpoint": "",
+        mock_getenv.return_value = None
+        
+        mock_settings.get.side_effect = lambda key, default=None: {
             "llm_model": "gemini-3-flash-preview",
             "max_results": 10,
             "safe_search": True,
-        }.get(key)
+        }.get(key, default)
 
         result = await perform_core_search("query", "summary")
         
-        assert "LLM not configured" in result['summary']
-        assert "Test Result 1" in result['summary']
-        assert "http://test1.com" in result['summary']
-        assert result['sources_used'] == 2
+        assert "No LLM endpoint configured" in result['summary']
+        assert result['sources_used'] == 0

--- a/tests/unit/test_search_service.py
+++ b/tests/unit/test_search_service.py
@@ -2,17 +2,16 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from services.search_service import perform_core_search
 
-# Sample search results
 MOCK_SEARCH_RESULTS = [
     {'title': 'Test Result 1', 'href': 'http://test1.com', 'body': 'Snippet 1'},
     {'title': 'Test Result 2', 'href': 'http://test2.com', 'body': 'Snippet 2'},
 ]
 
+
 @pytest.mark.asyncio
 async def test_search_no_results():
     """Test search when DDGS returns no results."""
     with patch('services.search_service.DDGS') as MockDDGS:
-        # Mock DDGS instance and text method
         mock_ddgs_instance = MockDDGS.return_value
         mock_ddgs_instance.__enter__.return_value = mock_ddgs_instance
         mock_ddgs_instance.text.return_value = []
@@ -22,56 +21,60 @@ async def test_search_no_results():
         assert result['summary'] == "No search results found for the query."
         assert result['sources_used'] == 0
 
+
 @pytest.mark.asyncio
-async def test_search_with_ai_summary():
-    """Test search flow when AI model is available."""
+async def test_search_with_llm():
+    """Test search flow when LLM endpoint is configured."""
     with patch('services.search_service.DDGS') as MockDDGS, \
          patch('services.search_service.scrape_webpage_content') as mock_scrape, \
-         patch('services.search_service.get_llm_model_with_retry') as mock_get_model:
+         patch('services.search_service.settings_manager') as mock_settings, \
+         patch('services.search_service.call_llm') as mock_call_llm:
         
-        # Mock DDGS
         mock_ddgs_instance = MockDDGS.return_value
         mock_ddgs_instance.__enter__.return_value = mock_ddgs_instance
         mock_ddgs_instance.text.return_value = MOCK_SEARCH_RESULTS
         
-        # Mock Scraper
         mock_scrape.return_value = "Full scraped content"
         
-        # Mock AI Model
-        mock_model = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = "AI Generated Summary"
-        mock_model.generate_content.return_value = mock_response
-        mock_model.generate_content_async = AsyncMock(return_value=mock_response)
+        mock_settings.get.side_effect = lambda key: {
+            "llm_endpoint": "http://localhost:11435",
+            "llm_model": "gemini-3-flash-preview",
+            "max_results": 10,
+            "safe_search": True,
+        }.get(key)
         
-        # Mock get_llm_model_with_retry to return our mock model
-        mock_get_model.return_value = mock_model
+        mock_call_llm.return_value = "AI Generated Summary"
 
         result = await perform_core_search("query", "summary")
         
         assert result['summary'] == "AI Generated Summary"
         assert result['sources_used'] == 2
-        mock_model.generate_content_async.assert_called_once()
+        mock_call_llm.assert_called_once()
+
 
 @pytest.mark.asyncio
-async def test_search_without_ai_key_fallback():
-    """Test fallback formatting when AI model is None."""
+async def test_search_without_llm_endpoint_fallback():
+    """Test fallback formatting when LLM endpoint is not configured."""
     with patch('services.search_service.DDGS') as MockDDGS, \
          patch('services.search_service.scrape_webpage_content') as mock_scrape, \
-         patch('services.search_service.get_llm_model_with_retry', return_value=None): # Mock model as None
+         patch('services.search_service.settings_manager') as mock_settings:
         
-        # Mock DDGS
         mock_ddgs_instance = MockDDGS.return_value
         mock_ddgs_instance.__enter__.return_value = mock_ddgs_instance
         mock_ddgs_instance.text.return_value = MOCK_SEARCH_RESULTS
         
-        # Mock Scraper
         mock_scrape.return_value = "Full scraped content"
+        
+        mock_settings.get.side_effect = lambda key: {
+            "llm_endpoint": "",
+            "llm_model": "gemini-3-flash-preview",
+            "max_results": 10,
+            "safe_search": True,
+        }.get(key)
 
         result = await perform_core_search("query", "summary")
         
-        # Check that we got the fallback formatted list
-        assert "AI Summarization unavailable" in result['summary']
+        assert "LLM not configured" in result['summary']
         assert "Test Result 1" in result['summary']
         assert "http://test1.com" in result['summary']
         assert result['sources_used'] == 2


### PR DESCRIPTION
## Summary
Integrates Web-Scout with LLM Wrapper as the LLM gateway, enabling AI-powered search result summarization.

## Changes
- Renamed `LLM_WRAPPER_URL` to `LLM_ENDPOINT_URL` for generic OpenAI-compatible endpoint support
- Fixed settings manager `get()` to accept optional default parameter
- Updated docker-compose to pass `LLM_ENDPOINT_URL` env var to web-scout
- Added `llm-endpoint-url` secret to Azure Key Vault (`nstutcommonkv`)
- Updated CI/CD workflow to fetch `llm-endpoint-url` from KV and pass to deploy trigger

## Acceptance Criteria
- [x] Web-Scout reads `LLM_ENDPOINT_URL` from environment variable
- [x] Falls back to settings.json if env var not set
- [x] Raises clear exception if no LLM endpoint configured
- [x] CI/CD fetches secret from Azure Key Vault during deploy

Closes #3